### PR TITLE
Hit detection test

### DIFF
--- a/Assets/Scripts/BossCircleCollider.cs
+++ b/Assets/Scripts/BossCircleCollider.cs
@@ -18,20 +18,10 @@ public class BossCircleCollider : MonoBehaviour {
 	void OnCollisionEnter2D(Collision2D collider)
 	{
 		Debug.Log ("HIT");
-		if (collider.gameObject.tag == "PlayerProjectile")
-		{
-            Destroy(collider.gameObject);
-			bossController.HitByPlayerProjectile();
-		}
 	}
 
     void OnTriggerEnter2D(Collider2D collider)
     {
         Debug.Log("HIT");
-        if (collider.gameObject.tag == "PlayerProjectile")
-        {
-            Destroy(collider.gameObject);
-            bossController.HitByPlayerProjectile();
-        }
     }
 }

--- a/Assets/Scripts/BossController.cs
+++ b/Assets/Scripts/BossController.cs
@@ -651,7 +651,9 @@ public class BossController : MonoBehaviour
     /**
      * Boss is hit by player.
      *
-     * Called by BossCirlceCollider.OnCollisionEnter2D()
+     * Called in LetterProjectileController.cs
+     * Called in LetterProjectile3Controller.cs
+     * Called in Letter2ProjectileController.cs
      */
     public void HitByPlayerProjectile()
     {

--- a/Assets/Scripts/BossProjectile.cs
+++ b/Assets/Scripts/BossProjectile.cs
@@ -9,33 +9,45 @@ public class BossProjectile : MonoBehaviour {
         Physics2D.IgnoreLayerCollision(LayerMask.NameToLayer("EnemyProjectile"), LayerMask.NameToLayer("Default"));
     }
 
-	void onTriggerEnter2D(Collision2D triggered)
-	{		
-		//If collides with player
-		if (triggered.collider.gameObject.tag == "Player")
-		{
-			Instantiate(enemyDeathEffect, triggered.transform.position, triggered.transform.rotation);
-            // Destroy is handled in player for better hit detection
-		}
-        else
+	void onTriggerEnter2D(Collision2D collided)
+	{
+        //If collides with player
+        if (collided.collider.gameObject.tag == "Player")
         {
-            //If it collides with anything, destroy projectile
-            Destroy(this.gameObject);
+            Instantiate(enemyDeathEffect, collided.transform.position, collided.transform.rotation);
+            Transform stats = collided.gameObject.transform.FindChild("Stats");
+            if (stats != null)
+            {
+                Player playerComponent = stats.GetComponent<Player>();
+                if (playerComponent != null)
+                    playerComponent.TakeDamage();
+            }
+            else
+            {
+                Debug.LogError(this.gameObject.name + ": Could not find Stats Object");
+            }
         }
+        Destroy(this.gameObject);
 	}
 
 	void OnCollisionEnter2D(Collision2D collided)
 	{
-		//If collides with player
+        //If collides with player
         if (collided.collider.gameObject.tag == "Player")
         {
             Instantiate(enemyDeathEffect, collided.transform.position, collided.transform.rotation);
-            // Destroy is handled in player for better hit detection
+            Transform stats = collided.gameObject.transform.FindChild("Stats");
+            if (stats != null)
+            {
+                Player playerComponent = stats.GetComponent<Player>();
+                if (playerComponent != null)
+                    playerComponent.TakeDamage();
+            }
+            else
+            {
+                Debug.LogError(this.gameObject.name + ": Could not find Stats Object");
+            }
         }
-        else
-        {
-            //If it collides with anything, destroy projectile
-            Destroy(this.gameObject);
-        }
+        Destroy(this.gameObject);
 	}
 }

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -190,11 +190,6 @@ public class EnemyController : MonoBehaviour
         {
             Hover();
         }
-
-        if (currentHealth <= 0)
-        {
-            EnemyDeath();
-        }
     }
 
 	private void PlaySound()
@@ -666,37 +661,19 @@ public class EnemyController : MonoBehaviour
      * Take damage when hit with the players projectile. When this entity gets hit
      * it will get a period in which it can not be hurt ('onCoolDown'), granting
      * it invincibility for a short period of time.
+     * 
+     * Called in LetterProjectileController.cs
+     * Called in LetterProjectile3Controller.cs
+     * Called in Letter2ProjectileController.cs
      */
-    void OnTriggerEnter2D(Collider2D collision)
+    public void TakeDamage()
     {
-        if (collision.gameObject.tag == "PlayerProjectile")
+        if (!onCoolDown)
         {
-            Destroy(collision.gameObject);
-            if (!onCoolDown && currentHealth > 0)
-            {
-                StartCoroutine(coolDownDMG());
-                //Debug.Log(this.gameObject.name + ": Au!");
-                currentHealth -= 1;
-            }
-        }
-    }
-
-    /**
-     * Take damage when hit with the players projectile. When this entity gets hit
-     * it will get a period in which it can not be hurt ('onCoolDown'), granting
-     * it invincibility for a short period of time.
-     */
-    void OnColliderEnter2D(Collision2D collision)
-    {
-        if (collision.gameObject.tag == "PlayerProjectile")
-        {
-            Destroy(collision.gameObject);
-            if (!onCoolDown && currentHealth > 0)
-            {
-                StartCoroutine(coolDownDMG());
-                //Debug.Log(this.gameObject.name + ": Au!");
-                currentHealth -= 1;
-            }
+            StartCoroutine(coolDownDMG());
+            currentHealth -= 1;
+            if (currentHealth <= 0)
+                EnemyDeath();
         }
     }
 

--- a/Assets/Scripts/EnemyProjectileController.cs
+++ b/Assets/Scripts/EnemyProjectileController.cs
@@ -39,6 +39,11 @@ public class EnemyProjectileController : MonoBehaviour {
         else if (collided.collider.gameObject.tag == "Friendly")
         {
             Instantiate(enemyDeathEffect, collided.transform.position, collided.transform.rotation);
+            FriendlyController friendlyController = collided.gameObject.GetComponent<FriendlyController>();
+            if (friendlyController != null)
+                friendlyController.TakeDamage();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find FriendlyController on Friendly target");
         }
         else
         {
@@ -68,6 +73,11 @@ public class EnemyProjectileController : MonoBehaviour {
         else if (collided.collider.gameObject.tag == "Friendly")
         {
             Instantiate(enemyDeathEffect, collided.transform.position, collided.transform.rotation);
+            FriendlyController friendlyController = collided.gameObject.GetComponent<FriendlyController>();
+            if (friendlyController != null)
+                friendlyController.TakeDamage();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find FriendlyController on Friendly target");
         }
         else
         {

--- a/Assets/Scripts/EnemyProjectileController.cs
+++ b/Assets/Scripts/EnemyProjectileController.cs
@@ -21,28 +21,58 @@ public class EnemyProjectileController : MonoBehaviour {
     void onTriggerEnter2D(Collision2D collided)
     {
         //If collides with player
-        if (collided.collider.gameObject.tag == "Player" || collided.collider.gameObject.tag == "Friendly")
+        if (collided.collider.gameObject.tag == "Player")
+        {
+            Instantiate(enemyDeathEffect, collided.transform.position, collided.transform.rotation);
+            Transform stats = collided.gameObject.transform.FindChild("Stats");
+            if (stats != null)
+            {
+                Player playerComponent = stats.GetComponent<Player>();
+                if (playerComponent != null)
+                    playerComponent.TakeDamage();
+            }
+            else
+            {
+                Debug.LogError(this.gameObject.name + ": Could not find Stats Object");
+            }
+        }
+        else if (collided.collider.gameObject.tag == "Friendly")
         {
             Instantiate(enemyDeathEffect, collided.transform.position, collided.transform.rotation);
         }
         else
         {
             AudioSource.PlayClipAtPoint(projectileHits, positie, 0.5f);
-            Destroy(this.gameObject);
         }
+        Destroy(this.gameObject);
     }
 
     void OnCollisionEnter2D(Collision2D collided)
     {
         //If collides with player
-        if (collided.collider.gameObject.tag == "Player" || collided.collider.gameObject.tag == "Friendly")
+        if (collided.collider.gameObject.tag == "Player")
+        {
+            Instantiate(enemyDeathEffect, collided.transform.position, collided.transform.rotation);
+            Transform stats = collided.gameObject.transform.FindChild("Stats");
+            if (stats != null)
+            {
+                Player playerComponent = stats.GetComponent<Player>();
+                if (playerComponent != null)
+                    playerComponent.TakeDamage();
+            }
+            else
+            {
+                Debug.LogError(this.gameObject.name + ": Could not find Stats Object");
+            }
+        }
+        else if (collided.collider.gameObject.tag == "Friendly")
         {
             Instantiate(enemyDeathEffect, collided.transform.position, collided.transform.rotation);
         }
         else
         {
             AudioSource.PlayClipAtPoint(projectileHits, positie, 0.5f);
-            Destroy(this.gameObject);
         }
+        Destroy(this.gameObject);
     }
 }

--- a/Assets/Scripts/FriendlyController.cs
+++ b/Assets/Scripts/FriendlyController.cs
@@ -160,11 +160,6 @@ public class FriendlyController : MonoBehaviour
                 Wait();
                 break;
         }
-
-        if (currentHealth <= 0)
-        {
-            FriendlyDeath();
-        }
     }
 
 	private void PlaySound()
@@ -296,9 +291,7 @@ public class FriendlyController : MonoBehaviour
     }
 
     /**
-     * Take damage when hit with an enemy projectile. When this entity gets hit
-     * it will get a period in which it can not be hurt ('onCoolDown'), granting
-     * it invincibility for a short period of time.
+     * Plays the message sounds when a player is near.
      */
     void OnTriggerEnter2D(Collider2D collision)
     {
@@ -306,16 +299,23 @@ public class FriendlyController : MonoBehaviour
 		{
 			StartCoroutine(PlaySound(message));
 		}
+    }
 
-        if (collision.gameObject.layer == LayerMask.NameToLayer("EnemyProjectile"))
+    /**
+     * Take damage when hit with an enemy projectile. When this entity gets hit
+     * it will get a period in which it can not be hurt ('onCoolDown'), granting
+     * it invincibility for a short period of time.
+     * 
+     * Called by EnemyProjectileController.cs
+     */
+    public void TakeDamage()
+    {
+        if (!onCoolDown)
         {
-            if (!onCoolDown && currentHealth > 0)
-            {
-                StartCoroutine(coolDownDMG());
-                //Debug.Log(this.gameObject.name + ": Au!");
-                currentHealth -= 1;
-            }
-            Destroy(collision.gameObject);
+            StartCoroutine(coolDownDMG());
+            currentHealth -= 1;
+            if (currentHealth <= 0)
+                FriendlyDeath();
         }
     }
 

--- a/Assets/Scripts/Letter2ProjectileController.cs
+++ b/Assets/Scripts/Letter2ProjectileController.cs
@@ -60,7 +60,7 @@ public class Letter2ProjectileController : MonoBehaviour {
 				hitPosition = transform.position.y;
 			}
 		}
-        if (col.gameObject.tag == "Enemy" || col.gameObject.tag == "Boss")
+        if (col.gameObject.tag == "Enemy")
         {
             /**
              * Needed for the boss to register a hit. This projectile can not 
@@ -68,6 +68,21 @@ public class Letter2ProjectileController : MonoBehaviour {
              */
             this.gameObject.GetComponent<Rigidbody2D>().isKinematic = false;
             
+            Instantiate(enemyDeathEffect, col.transform.position, col.transform.rotation);
+            EnemyController enemyController = col.gameObject.GetComponent<EnemyController>();
+            if (enemyController != null)
+                enemyController.TakeDamage();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find EnemyController on Enemy target");
+        }
+        else if (col.gameObject.tag == "Boss")
+        {
+            /**
+             * Needed for the boss to register a hit. This projectile can not 
+             * be kinematic if it needs to trigger a collider.
+             */
+            this.gameObject.GetComponent<Rigidbody2D>().isKinematic = false;
+
             Instantiate(enemyDeathEffect, col.transform.position, col.transform.rotation);
             // The enemy and boss will destroy this object to ensure it detects the hit properly
         }

--- a/Assets/Scripts/Letter2ProjectileController.cs
+++ b/Assets/Scripts/Letter2ProjectileController.cs
@@ -29,6 +29,9 @@ public class Letter2ProjectileController : MonoBehaviour {
 		if (player.transform.localScale.x > 0) {
             speed = 2.0f;
 		}
+
+        if (this.gameObject != null)
+            Destroy(this.gameObject, 3.5f);
 	}
 	
 	// Update is called once per frame
@@ -62,30 +65,30 @@ public class Letter2ProjectileController : MonoBehaviour {
 		}
         if (col.gameObject.tag == "Enemy")
         {
-            /**
-             * Needed for the boss to register a hit. This projectile can not 
-             * be kinematic if it needs to trigger a collider.
-             */
-            this.gameObject.GetComponent<Rigidbody2D>().isKinematic = false;
-            
             Instantiate(enemyDeathEffect, col.transform.position, col.transform.rotation);
             EnemyController enemyController = col.gameObject.GetComponent<EnemyController>();
             if (enemyController != null)
                 enemyController.TakeDamage();
             else
                 Debug.LogError(this.gameObject.name + ": Could not find EnemyController on Enemy target");
+
+            Destroy(this.gameObject);
         }
         else if (col.gameObject.tag == "Boss")
         {
-            /**
-             * Needed for the boss to register a hit. This projectile can not 
-             * be kinematic if it needs to trigger a collider.
-             */
-            this.gameObject.GetComponent<Rigidbody2D>().isKinematic = false;
-
             Instantiate(enemyDeathEffect, col.transform.position, col.transform.rotation);
-            // The enemy and boss will destroy this object to ensure it detects the hit properly
+            Transform bossTransform = col.transform.parent.transform;
+            if (bossTransform.name != "Boss")
+            {
+                Debug.LogError("BossParent Not Found! Returned parent : " + bossTransform.name);
+            }
+            BossController bossController = bossTransform.GetComponent<BossController>();
+            if (bossController != null)
+                bossController.HitByPlayerProjectile();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find BossController on Boss target");
+
+            Destroy(this.gameObject);
         }
-		Destroy(this.gameObject, 3.5f);
 	}
 }

--- a/Assets/Scripts/LetterProjectile3Controller.cs
+++ b/Assets/Scripts/LetterProjectile3Controller.cs
@@ -40,7 +40,16 @@ public class LetterProjectile3Controller : MonoBehaviour {
 
     void onTriggerEnter2D(Collision2D collider)
     {
-        if (collider.gameObject.tag == "Enemy" || collider.gameObject.tag == "Boss")
+        if (collider.gameObject.tag == "Enemy")
+        {
+            Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
+            EnemyController enemyController = collider.gameObject.GetComponent<EnemyController>();
+            if (enemyController != null)
+                enemyController.TakeDamage();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find EnemyController on Enemy target");
+        }
+        else if (collider.gameObject.tag == "Boss")
         {
             Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
             // The enemy and boss will destroy this object to ensure it detects the hit properly
@@ -54,7 +63,16 @@ public class LetterProjectile3Controller : MonoBehaviour {
 
     void OnCollisionEnter2D(Collision2D collider)
     {
-        if (collider.gameObject.tag == "Enemy" || collider.gameObject.tag == "Boss")
+        if (collider.gameObject.tag == "Enemy")
+        {
+            Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
+            EnemyController enemyController = collider.gameObject.GetComponent<EnemyController>();
+            if (enemyController != null)
+                enemyController.TakeDamage();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find EnemyController on Enemy target");
+        }
+        else if (collider.gameObject.tag == "Boss")
         {
             Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
             // The enemy and boss will destroy this object to ensure it detects the hit properly

--- a/Assets/Scripts/LetterProjectile3Controller.cs
+++ b/Assets/Scripts/LetterProjectile3Controller.cs
@@ -25,6 +25,8 @@ public class LetterProjectile3Controller : MonoBehaviour {
 		if (player.transform.localScale.x > 0) {
             speed = 1f;
 		}
+        if (this.gameObject != null)
+            Destroy(this.gameObject, 5);
 	}
 	
 	// Update is called once per frame
@@ -34,8 +36,6 @@ public class LetterProjectile3Controller : MonoBehaviour {
 			AudioSource.PlayClipAtPoint (_audioClip, position, 0.1f);
 			isPlayed = true;
 		}
-        if (this.gameObject != null)
-		    Destroy (this.gameObject,5);
 	}
 
     void onTriggerEnter2D(Collision2D collider)
@@ -52,13 +52,22 @@ public class LetterProjectile3Controller : MonoBehaviour {
         else if (collider.gameObject.tag == "Boss")
         {
             Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
-            // The enemy and boss will destroy this object to ensure it detects the hit properly
+            Transform bossTransform = collider.transform.parent.transform;
+            if (bossTransform.name != "Boss")
+            {
+                Debug.LogError("BossParent Not Found! Returned parent : " + bossTransform.name);
+            }
+            BossController bossController = bossTransform.GetComponent<BossController>();
+            if (bossController != null)
+                bossController.HitByPlayerProjectile();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find BossController on Boss target");
         }
         else
         {
             Instantiate(impactEffect, transform.position, transform.rotation);
-            Destroy(this.gameObject);
         }
+        Destroy(this.gameObject);
     }
 
     void OnCollisionEnter2D(Collision2D collider)
@@ -75,12 +84,21 @@ public class LetterProjectile3Controller : MonoBehaviour {
         else if (collider.gameObject.tag == "Boss")
         {
             Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
-            // The enemy and boss will destroy this object to ensure it detects the hit properly
+            Transform bossTransform = collider.transform.parent.transform;
+            if (bossTransform.name != "Boss")
+            {
+                Debug.LogError("BossParent Not Found! Returned parent : " + bossTransform.name);
+            }
+            BossController bossController = bossTransform.GetComponent<BossController>();
+            if (bossController != null)
+                bossController.HitByPlayerProjectile();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find BossController on Boss target");
         }
         else
         {
             Instantiate(impactEffect, transform.position, transform.rotation);
-            Destroy(this.gameObject);
         }
+        Destroy(this.gameObject);
     }
 }

--- a/Assets/Scripts/LetterProjectileController.cs
+++ b/Assets/Scripts/LetterProjectileController.cs
@@ -32,7 +32,16 @@ public class LetterProjectileController : MonoBehaviour {
 
     void onTriggerEnter2D(Collision2D collider)
     {
-        if (collider.gameObject.tag == "Enemy" || collider.gameObject.tag == "Boss")
+        if (collider.gameObject.tag == "Enemy")
+        {
+            Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
+            EnemyController enemyController = collider.gameObject.GetComponent<EnemyController>();
+            if (enemyController != null)
+                enemyController.TakeDamage();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find EnemyController on Enemy target");
+        }
+        else if (collider.gameObject.tag == "Boss")
         {
             Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
             // The enemy and boss will destroy this object to ensure it detects the hit properly
@@ -46,7 +55,16 @@ public class LetterProjectileController : MonoBehaviour {
 
 	void OnCollisionEnter2D(Collision2D collider)
 	{
-        if (collider.gameObject.tag == "Enemy" || collider.gameObject.tag == "Boss")
+        if (collider.gameObject.tag == "Enemy")
+        {
+            Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
+            EnemyController enemyController = collider.gameObject.GetComponent<EnemyController>();
+            if (enemyController != null)
+                enemyController.TakeDamage();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find EnemyController on Enemy target");
+        }
+        else if (collider.gameObject.tag == "Boss")
         {
             Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
             // The enemy and boss will destroy this object to ensure it detects the hit properly

--- a/Assets/Scripts/LetterProjectileController.cs
+++ b/Assets/Scripts/LetterProjectileController.cs
@@ -21,13 +21,13 @@ public class LetterProjectileController : MonoBehaviour {
 		if (player.transform.localScale.x > 0) {
 			transform.forward = -transform.forward;
 		}
+        if (this.gameObject != null)
+            Destroy(this.gameObject, 2);
 	}
 	
 	// Update is called once per frame
 	void Update () {
 		GetComponent<Rigidbody2D>().velocity = new Vector2 (speed, GetComponent<Rigidbody2D>().velocity.y);
-        if (this.gameObject != null)
-		    Destroy (this.gameObject,2);
 	}
 
     void onTriggerEnter2D(Collision2D collider)
@@ -44,13 +44,23 @@ public class LetterProjectileController : MonoBehaviour {
         else if (collider.gameObject.tag == "Boss")
         {
             Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
-            // The enemy and boss will destroy this object to ensure it detects the hit properly
+            Transform bossTransform = collider.transform.parent.transform;
+            if (bossTransform.name != "Boss")
+            {
+                Debug.LogError("BossParent Not Found! Returned parent : " + bossTransform.name);
+            }
+            BossController bossController = bossTransform.GetComponent<BossController>();
+            if (bossController != null)
+                bossController.HitByPlayerProjectile();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find BossController on Boss target");
         }
         else
         {
             Instantiate(impactEffect, transform.position, transform.rotation);
-            Destroy(this.gameObject);
         }
+        Destroy(this.gameObject);
+
     }
 
 	void OnCollisionEnter2D(Collision2D collider)
@@ -67,12 +77,21 @@ public class LetterProjectileController : MonoBehaviour {
         else if (collider.gameObject.tag == "Boss")
         {
             Instantiate(enemyDeathEffect, collider.transform.position, collider.transform.rotation);
-            // The enemy and boss will destroy this object to ensure it detects the hit properly
+            Transform bossTransform = collider.transform.parent.transform;
+            if (bossTransform.name != "Boss")
+            {
+                Debug.LogError("BossParent Not Found! Returned parent : " + bossTransform.name);
+            }
+            BossController bossController = bossTransform.GetComponent<BossController>();
+            if (bossController != null)
+                bossController.HitByPlayerProjectile();
+            else
+                Debug.LogError(this.gameObject.name + ": Could not find BossController on Boss target");
         }
         else
         {
             Instantiate(impactEffect, transform.position, transform.rotation);
-            Destroy(this.gameObject);
         }
+        Destroy(this.gameObject);
 	}
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -188,25 +188,6 @@ public class Player : MonoBehaviour {
 
 	void OnTriggerStay2D(Collider2D collision)
 	{
-		if (collision.gameObject.tag == "Enemy") // Near enemy? Health goes down every 2 seconds
-		{
-            if (!onCoolDown && currentHealth > 0)
-            {
-                Object spawnedImpactEffect = Instantiate(impactEffect, transform.position, transform.rotation);
-                StartCoroutine(coolDownDMG());
-                CurrentHealth -= 1;
-                GameControl.control.damageTaken++; // Used for analytics
-                Destroy(spawnedImpactEffect, 1);
-            }
-            else if (currentHealth == 0)
-            {
-                Respawn();
-            }
-
-            if (LayerMask.LayerToName(collision.gameObject.layer) == "EnemyProjectile")
-                Destroy(collision.gameObject);
-		}        
-		
         if (collision.gameObject.tag == "Water")
         {
             if (currentHealth > 0)
@@ -223,7 +204,11 @@ public class Player : MonoBehaviour {
 	}
 
 	void OnTriggerEnter2D (Collider2D collision)
-	{        
+	{
+        if (collision.gameObject.tag == "Enemy") // Near enemy? Health goes down every 2 seconds
+        {
+            TakeDamage();
+        }
 		if (collision.gameObject.tag == "Letter") 
 		{
 			if (countLetters < maxLetters)
@@ -395,14 +380,8 @@ public class Player : MonoBehaviour {
             if (currentHealth > 0)
             {
                 rb.AddForce(Vector3.up * 300);
-                
-                if (!onCoolDown)
-                {
-                    Object spawnedImpactEffect = Instantiate(impactEffect, transform.position, transform.rotation);
-                    StartCoroutine(coolDownDMG());
-                    CurrentHealth -= 1;
-                    Destroy(spawnedImpactEffect, 1);
-                }             
+
+                TakeDamage();          
             }
             else
             {
@@ -412,15 +391,7 @@ public class Player : MonoBehaviour {
 
         if (collision.gameObject.tag == "ijstand") // Near enemy? Health goes down every 2 seconds
         {
-            if (!onCoolDown && currentHealth > 0)
-            {
-                StartCoroutine(coolDownDMG());
-                CurrentHealth -= 1;
-            }
-            else if (currentHealth == 0)
-            {
-                Respawn();
-            }
+            TakeDamage();
         }      
 	}
 
@@ -478,6 +449,20 @@ public class Player : MonoBehaviour {
             kindPlus = false;
         }
 	}
+
+    public void TakeDamage()
+    {
+        if (!onCoolDown)
+        {
+            Object spawnedImpactEffect = Instantiate(impactEffect, transform.position, transform.rotation);
+            StartCoroutine(coolDownDMG());
+            CurrentHealth -= 1;
+            GameControl.control.damageTaken++; // Used for analytics
+            Destroy(spawnedImpactEffect, 1);
+            if (currentHealth <= 0)
+                Respawn();
+        }
+    }
 
     IEnumerator PlusOneActive()
     {


### PR DESCRIPTION
Moved the decision on when to take damage to the projectiles in stead of the objects themselves.

This should fix the bug that sometimes you seem to be able to move a projectile by jumping on it or moving it. It wouldn't trigger the destroy projectile properly. By moving the collision detection to the projectile it should.
